### PR TITLE
Fix DHCP renew

### DIFF
--- a/Internet/DHCP/dhcp.c
+++ b/Internet/DHCP/dhcp.c
@@ -978,11 +978,9 @@ uint32_t getDHCPTimeBeforeLease(void){
 
 void DHCP_renew(void)
 {
-	uint8_t zeroip[4] = {0,0,0,0};
-	setSIPR(zeroip);
-	setGAR(zeroip);
-	reset_DHCP_timeout();
-	dhcp_state = DHCP_IP_LEASED;
+	dhcp_lease_time = 0;
+	if(dhcp_state != STATE_DHCP_LEASED)
+		dhcp_state = STATE_DHCP_INIT;
 }
 
 


### PR DESCRIPTION
Fixed DHCP renew issue, when network cable is plugged and unplugged(or link is up/down).

How to reproduce:
-Check incoming DHCP packets
-Plug unplug and plug network cable
MUEB tries to renew it's IP with incorrect **`0.0.0.0`** IP address => **OS/server drops the packet**

Before:
![image](https://user-images.githubusercontent.com/33965876/49883245-910a6e80-fe32-11e8-84f7-ec496b0af545.png)

After:
![image](https://user-images.githubusercontent.com/33965876/49882902-dda17a00-fe31-11e8-82f7-22bbc697830e.png)

**pcap**
[dhcp-renew-fix.zip](https://github.com/kissadamfkut/ioLibrary_Driver/files/2672626/dhcp-renew-fix.zip)